### PR TITLE
AX-1754-Update JFrog skills context and description to clarify MCP server man…

### DIFF
--- a/skills/jfrog/SKILL.md
+++ b/skills/jfrog/SKILL.md
@@ -13,10 +13,7 @@ description: >-
   Also use when the user mentions jf, jfrog, artifactory, xray, distribution,
   evidence, apptrust, onemodel, graphql, workers, mission control, curation,
   advanced security, exposures, or any JFrog product name.
-  Do NOT use this skill to install, add, remove, list, or manage MCP servers
-  (e.g. "install an MCP", "what MCPs can I install", "list my MCPs", "which MCP
-  servers can I use", "what's in my approved MCP catalog") — MCP server
-  management is handled by the JFrog Agent Guard workflow, not this skill.
+  Do NOT use this skill to install, add, remove, list, or manage MCP servers.
 compatibility: >-
   Requires jq on PATH.
 metadata:
@@ -35,8 +32,10 @@ by the agent. If the agent does not resolve it, determine the path by locating
 this SKILL.md file and using its parent directory.
 
 > **Out of scope: MCP server management.** Installing, listing, removing, or
-> configuring MCP servers (via JFrog Agent Guard / `@jfrog/agent-guard`) is a
-> separate workflow, not this skill.
+> configuring MCP servers (e.g. "install an MCP", "what MCPs can I install",
+> "list my MCPs", "which MCP servers can I use", "what's in my approved MCP
+> catalog") is handled by the JFrog Agent Guard workflow
+> (`@jfrog/agent-guard`) — a separate workflow, not this skill.
 
 ## Tool selection strategy
 

--- a/skills/jfrog/SKILL.md
+++ b/skills/jfrog/SKILL.md
@@ -13,6 +13,10 @@ description: >-
   Also use when the user mentions jf, jfrog, artifactory, xray, distribution,
   evidence, apptrust, onemodel, graphql, workers, mission control, curation,
   advanced security, exposures, or any JFrog product name.
+  Do NOT use this skill to install, add, remove, list, or manage MCP servers
+  (e.g. "install an MCP", "what MCPs can I install", "list my MCPs", "which MCP
+  servers can I use", "what's in my approved MCP catalog") — MCP server
+  management is handled by the JFrog Agent Guard workflow, not this skill.
 compatibility: >-
   Requires jq on PATH.
 metadata:
@@ -29,6 +33,10 @@ Interact with the JFrog Platform through three tool tiers — see
 `<skill_path>` refers to this skill's directory and is resolved automatically
 by the agent. If the agent does not resolve it, determine the path by locating
 this SKILL.md file and using its parent directory.
+
+> **Out of scope: MCP server management.** Installing, listing, removing, or
+> configuring MCP servers (via JFrog Agent Guard / `@jfrog/agent-guard`) is a
+> separate workflow, not this skill.
 
 ## Tool selection strategy
 


### PR DESCRIPTION
---
  **Title:**
     AX-1754-Change-the-Jfrog-skills-context-and-description
  Body:

  **Summary**

  The jfrog skill was claiming MCP-server availability/installation prompts and answering them directly, instead of deferring to the JFrog Agent Guard workflow (agent-guard --list-available). This adds an explicit scope
  boundary so those prompts route to Agent Guard. Root cause and impact:
  RCA for the 2026-06-18 MCP-routing incidents.

  **What changed**

  skills/jfrog/SKILL.md (+8 lines, additive, no deletions):
  - Added a Do NOT use this skill to … MCP servers exclusion to the description — the field that drives skill activation — naming the exact phrases Agent Guard owns (e.g. "which MCP servers can I use", "what's in my approved 
  MCP catalog").
  - Added a matching "Out of scope: MCP server management" note in the skill body.

     advanced security, exposures, or any JFrog product name.
  +  Do NOT use this skill to install, add, remove, list, or manage MCP servers
  +  (e.g. "install an MCP", "what MCPs can I install", "list my MCPs", "which MCP
  +  servers can I use", "what's in my approved MCP catalog") — MCP server
  +  management is handled by the JFrog Agent Guard workflow, not this skill.

  **Why**
  
  The description's broad triggers ("any JFrog product name", "JFrog MCP server") let the skill win over the Agent Guard routing rule for the four  catalog/install prompts. Legitimate platform operations and Public-Catalog
  MCP-metadata queries are unaffected.

  **Verification**

  Blind A/B routing test on the four prompts (each version of the description fed to a fresh router-agent, neither told which was before/after):
  - Before: 1/4 mis-routed into the skill; the other 3 "skips" reached via ambiguous reasoning (matches the RCA's inconsistent repro).
  - After: 4/4 deferred to Agent Guard, deterministically.

  ---