### PR TITLE
Replace PLUGIN_SYNC_TOKEN with GitHub App auth for plugin sync

### DIFF
--- a/.github/workflows/sync-plugins.yml
+++ b/.github/workflows/sync-plugins.yml
@@ -4,9 +4,12 @@ name: Sync Plugins
 # listed in .github/plugins.json. Each PR vendors this repo's skills/
 # at the tag into the plugin repo.
 #
-# Required repo secret:
-#   PLUGIN_SYNC_TOKEN  PAT with Contents:write + Pull requests:write on every
-#                      jfrog/<plugin-name> repo in plugins.json.
+# Auth: jfrog-agentic-release-bot GitHub App → short-lived installation token.
+#   vars.PUBLIC_REPO_APP_ID + secrets.PUBLIC_REPO_APP_PRIVATE_KEY
+#   App needs Contents:write + Pull requests:write on every jfrog/<plugin>
+#   repo in plugins.json. Mint with explicit permission-* inputs.
+#   github-api-url is pinned to api.github.com for consistency with the
+#   GHES agent-hooks sync (harmless when this workflow already runs on github.com).
 
 on:
   push:
@@ -44,6 +47,18 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
+      - name: Generate github.com App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PUBLIC_REPO_APP_ID }}
+          private-key: ${{ secrets.PUBLIC_REPO_APP_PRIVATE_KEY }}
+          owner: jfrog
+          repositories: ${{ matrix.name }}
+          github-api-url: https://api.github.com
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@v4
 
       - uses: actions/checkout@v4
@@ -54,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: jfrog/${{ matrix.name }}
-          token: ${{ secrets.PLUGIN_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: plugin
 
       - name: Copy skills into plugin
@@ -66,7 +81,10 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         with:
           path: plugin
-          token: ${{ secrets.PLUGIN_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          # Bot *user* id (276080306), not App id (3378254) — required for attribution.
+          author: jfrog-agentic-release-bot[bot] <276080306+jfrog-agentic-release-bot[bot]@users.noreply.github.com>
+          committer: jfrog-agentic-release-bot[bot] <276080306+jfrog-agentic-release-bot[bot]@users.noreply.github.com>
           branch: chore/sync-skills-${{ env.VERSION }}
           delete-branch: true
           commit-message: 'chore: sync skills to ${{ env.VERSION }}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,9 @@ To re-trigger a sync for an existing tag, run the workflow manually from the Act
 
 ### Required setup
 
-- Repo secret `PLUGIN_SYNC_TOKEN`: a fine-grained PAT (or classic PAT with `repo` scope) with `Contents: write` and `Pull requests: write` on every plugin listed in `plugins.json`.
+- GitHub App **jfrog-agentic-release-bot** auth: `vars.PUBLIC_REPO_APP_ID` +
+  `secrets.PUBLIC_REPO_APP_PRIVATE_KEY`. The App needs `Contents: write` and
+  `Pull requests: write` on every plugin listed in `plugins.json`.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
## Overview
Stop using the long-lived `PLUGIN_SYNC_TOKEN` PAT for plugin sync. CI now mints short-lived installation tokens from **jfrog-agentic-release-bot** via `actions/create-github-app-token`, matching the agent-hooks change in [JFROG/jfrog-agent-hooks#89](https://github.jfrog.info/JFROG/jfrog-agent-hooks/pull/89).

## Details
- `sync-plugins.yml` generates an App token with `vars.PUBLIC_REPO_APP_ID` + `secrets.PUBLIC_REPO_APP_PRIVATE_KEY`, scoped to each matrix plugin repo (`jfrog/<name>`).
- Plugin checkout and `peter-evans/create-pull-request` use that token instead of `PLUGIN_SYNC_TOKEN`.
- Sync commits/PRs are authored as `jfrog-agentic-release-bot[bot]` (bot user id `276080306`).
- `CONTRIBUTING.md` documents the new App auth setup.

## Flow
```mermaid
flowchart LR
  SyncJob["sync-plugins on github.com"] --> Mint["create-github-app-token"]
  Mint -->|api.github.com| App["jfrog-agentic-release-bot"]
  App --> Token["installation token"]
  Token --> Plugins["jfrog/*-plugin"]
```

## Notes
- Requires `vars.PUBLIC_REPO_APP_ID` and `secrets.PUBLIC_REPO_APP_PRIVATE_KEY` on this repo.
- App must remain installed on the plugin repos listed in `.github/plugins.json`.
- Safe to delete the `PLUGIN_SYNC_TOKEN` secret after merge and a successful sync.