### PR TITLE
Harden Sync Plugins manual runs and bump Actions

### DIFF
--- a/.github/scripts/jfrog-sync-plugins.py
+++ b/.github/scripts/jfrog-sync-plugins.py
@@ -30,6 +30,9 @@ def fail(msg: str) -> None:
 def create_matrix() -> None:
     """Emit a GitHub Actions matrix from .github/plugins.json.
 
+    Optional env:
+      PLUGIN  Plugin name to include, or "all" (default). Unknown names fail.
+
     Writes `matrix=<compact-json>` to $GITHUB_OUTPUT and prints it to stdout.
 
     Example input (.github/plugins.json):
@@ -39,7 +42,15 @@ def create_matrix() -> None:
         matrix={"include":[{"name":"claude-plugin","dest_prefix":""}]}
     """
     data: dict = json.loads(PLUGINS_FILE.read_text())
-    matrix: dict = {"include": data["plugins"]}
+    plugins: list[dict] = data["plugins"]
+    plugin_filter: str = (os.environ.get("PLUGIN") or "all").strip()
+    if plugin_filter and plugin_filter != "all":
+        known = [p["name"] for p in plugins]
+        plugins = [p for p in plugins if p["name"] == plugin_filter]
+        if not plugins:
+            fail(f"unknown plugin {plugin_filter!r}; known: {', '.join(known)}")
+
+    matrix: dict = {"include": plugins}
 
     output_file: str | None = os.environ.get("GITHUB_OUTPUT")
     if output_file:

--- a/.github/workflows/sync-plugins.yml
+++ b/.github/workflows/sync-plugins.yml
@@ -20,6 +20,18 @@ on:
         description: 'Version tag to sync (e.g. v0.11.0).'
         required: true
         type: string
+      plugin:
+        description: 'Plugin to sync. "all" syncs every entry in plugins.json.'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - claude-plugin
+          - cursor-plugin
+          - vscode-plugin
+          - codex-plugin
+          - opencode-jfrog-plugin
 
 permissions:
   contents: read
@@ -37,6 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: matrix
+        env:
+          # Tag pushes have no inputs → all. Manual runs pass the choice input.
+          PLUGIN: ${{ github.event.inputs.plugin || 'all' }}
         run: python3 .github/scripts/jfrog-sync-plugins.py matrix
 
   sync:

--- a/.github/workflows/sync-plugins.yml
+++ b/.github/workflows/sync-plugins.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag to sync (e.g. v0.11.0).'
+        description: 'Version to sync (e.g. 0.22.0).'
         required: true
         type: string
       plugin:
@@ -36,18 +36,45 @@ on:
 permissions:
   contents: read
 
-# For tag pushes, github.ref_name is the tag. For manual dispatch, use the input.
-env:
-  VERSION: ${{ github.event.inputs.version || github.ref_name }}
-
 jobs:
   prepare:
     name: Build plugin matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Manual runs often omit the leading v (0.22.0); tags are always v*.
+      - id: version
+        env:
+          RAW: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$RAW" in
+            v*) version="$RAW" ;;
+            *)  version="v$RAW" ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Normalized VERSION=$version (from $RAW)"
+
+      - name: Verify version tag exists
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::Tag '$VERSION' does not exist in this repository. Pass an existing release tag (e.g. v0.22.0)."
+            echo "Recent tags:"
+            git tag --list 'v*' --sort=-v:refname | head -20
+            exit 1
+          fi
+          echo "Verified tag $VERSION -> $(git rev-parse "refs/tags/$VERSION")"
+
       - id: matrix
         env:
           # Tag pushes have no inputs → all. Manual runs pass the choice input.
@@ -61,10 +88,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Generate github.com App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.PUBLIC_REPO_APP_ID }}
           private-key: ${{ secrets.PUBLIC_REPO_APP_PRIVATE_KEY }}
@@ -74,14 +103,14 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.VERSION }}
           path: upstream
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: jfrog/${{ matrix.name }}
           token: ${{ steps.app-token.outputs.token }}
@@ -94,7 +123,7 @@ jobs:
           PIN_UPDATES: ${{ toJson(matrix.pin_updates) }}
         run: python3 .github/scripts/jfrog-sync-plugins.py copy
 
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         with:
           path: plugin
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Resolve PR details
         id: resolve-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = parseInt('${{ github.event.inputs.pr-number }}', 10);
@@ -44,7 +44,7 @@ jobs:
             console.log(`PR #${prNumber} by ${pr.user.login}: ${pr.title}`);
             console.log(`Head: ${pr.head.ref} @ ${pr.head.sha}`);
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.resolve-pr.outputs.head_sha }}
 
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
     steps:
       - name: Approve and merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = parseInt('${{ needs.validate.outputs.pr-number }}', 10);
@@ -160,7 +160,7 @@ jobs:
                 owner, repo,
                 workflow_id: 'sync-plugins.yml',
                 ref: 'main',
-                inputs: { version: tag }
+                inputs: { version: tag, plugin: 'all' }
               });
               console.log(`Dispatched.`);
             }


### PR DESCRIPTION
## Overview
Hardens manual Sync Plugins runs (single-plugin targeting, clearer version handling) and bumps GitHub Actions to current majors.

## Details
- **Plugin filter**: `workflow_dispatch` can sync `all` or one plugin from `plugins.json`. Tag pushes still sync every plugin.
- **Version normalize + verify**: accepts `0.22.0`, normalizes to `v0.22.0`, and fails in prepare if that tag is missing (with recent tags listed) instead of an opaque checkout error.
- **Actions majors**: `checkout` v7, `create-github-app-token` v3, `create-pull-request` v8, `github-script` v9.
- **validate-release**: Sync Plugins dispatch now passes `plugin: all` so it stays compatible with the required input.

## Flow
```mermaid
flowchart TD
  Trigger{"workflow_dispatch or tag push?"}
  Trigger -->|"tag push"| All["PLUGIN=all"]
  Trigger -->|"manual"| Choice["PLUGIN from choice input"]
  Trigger --> Norm["Normalize version to v*"]
  Norm --> Verify{"Tag exists?"}
  Verify -->|"no"| Fail["Fail prepare with recent tags"]
  Verify -->|"yes"| Matrix["Build filtered matrix"]
  All --> Matrix
  Choice --> Matrix
  Matrix --> Sync["Sync job per matrix entry"]
```

## Notes
- When adding a plugin to `plugins.json`, also add it to the workflow `options` list.
- Manual version input example: `0.22.0` (leading `v` is still accepted and normalized).