### PR TITLE
Add Devin, Kiro, and JetBrains plugins to release sync

### DIFF
--- a/.github/plugins.json
+++ b/.github/plugins.json
@@ -46,6 +46,43 @@
       "pin_updates": [
         { "file": "sync-skills-vendor.json", "path": "pin" }
       ]
+    },
+    {
+      "name": "jfrog-devin-extension",
+      "dest_prefix": "",
+      "version_bumps": [
+        { "file": "package.json", "path": "version" }
+      ],
+      "pin_updates": [
+        { "file": ".github/scripts/sync-skills-vendor.json", "path": "pin" }
+      ]
+    },
+    {
+      "name": "jfrog-kiro-power",
+      "dest_prefix": "",
+      "version_bumps": [
+        { "file": "package.json", "path": "version" }
+      ],
+      "pin_updates": [
+        { "file": "scripts/sync-skills-vendor.json", "path": "pin" }
+      ]
+    },
+    {
+      "name": "devin-plugin",
+      "dest_prefix": "",
+      "version_bumps": [
+        { "file": ".devin-plugin/plugin.json", "path": "version" }
+      ],
+      "pin_updates": [
+        { "file": ".github/scripts/sync-skills-vendor.json", "path": "pin" }
+      ]
+    },
+    {
+      "name": "jetbrains-plugin",
+      "dest_prefix": ".junie",
+      "pin_updates": [
+        { "file": ".github/scripts/sync-skills-vendor.json", "path": "pin" }
+      ]
     }
   ]
 }

--- a/.github/workflows/sync-plugins.yml
+++ b/.github/workflows/sync-plugins.yml
@@ -32,6 +32,10 @@ on:
           - vscode-plugin
           - codex-plugin
           - opencode-jfrog-plugin
+          - jfrog-devin-extension
+          - jfrog-kiro-power
+          - devin-plugin
+          - jetbrains-plugin
 
 permissions:
   contents: read

--- a/tests/test_jfrog_sync_plugins.py
+++ b/tests/test_jfrog_sync_plugins.py
@@ -48,6 +48,23 @@ class TestPluginsJsonPinUpdates(unittest.TestCase):
             by_name["opencode-jfrog-plugin"]["pin_updates"],
             [{"file": "sync-skills-vendor.json", "path": "pin"}],
         )
+        self.assertEqual(
+            by_name["jfrog-devin-extension"]["pin_updates"],
+            [{"file": ".github/scripts/sync-skills-vendor.json", "path": "pin"}],
+        )
+        self.assertEqual(
+            by_name["jfrog-kiro-power"]["pin_updates"],
+            [{"file": "scripts/sync-skills-vendor.json", "path": "pin"}],
+        )
+        self.assertEqual(
+            by_name["devin-plugin"]["pin_updates"],
+            [{"file": ".github/scripts/sync-skills-vendor.json", "path": "pin"}],
+        )
+        self.assertEqual(
+            by_name["jetbrains-plugin"]["pin_updates"],
+            [{"file": ".github/scripts/sync-skills-vendor.json", "path": "pin"}],
+        )
+        self.assertEqual(by_name["jetbrains-plugin"]["dest_prefix"], ".junie")
 
 
 class TestCopyPinUpdates(unittest.TestCase):


### PR DESCRIPTION
## Overview
Extends the Sync Plugins release pipeline so a `v*` skills release also opens vendoring PRs in four additional downstream plugin repos.

## Details
Adds these targets to `.github/plugins.json` (and the Sync Plugins workflow dispatch options):

- `jfrog-devin-extension` — skills at repo root; bumps `package.json`; pin at `.github/scripts/sync-skills-vendor.json`
- `jfrog-kiro-power` — skills at repo root; bumps `package.json`; pin at `scripts/sync-skills-vendor.json`
- `devin-plugin` — skills at repo root; bumps `.devin-plugin/plugin.json`; pin at `.github/scripts/sync-skills-vendor.json`
- `jetbrains-plugin` — skills land at `.junie/skills/` (`dest_prefix: .junie`); pin only (VERSION / `gradle.properties` are not JSON, so no automatic version bump)

Unit tests assert the new pin paths and JetBrains `dest_prefix`.

## Notes
- Ensure **jfrog-agentic-release-bot** is installed on these four repos with Contents + Pull requests write before the next sync run.
- JetBrains still needs a manual VERSION / `gradle.properties` bump before tagging a plugin release.
- Kiro sync PRs may also need `gen-steering` / `sync-pin` so CI does not fail on steering drift.