### PR TITLE
Drop archived Devin from plugin sync and use App client-id

### DIFF
--- a/.github/plugins.json
+++ b/.github/plugins.json
@@ -48,16 +48,6 @@
       ]
     },
     {
-      "name": "jfrog-devin-extension",
-      "dest_prefix": "",
-      "version_bumps": [
-        { "file": "package.json", "path": "version" }
-      ],
-      "pin_updates": [
-        { "file": ".github/scripts/sync-skills-vendor.json", "path": "pin" }
-      ]
-    },
-    {
       "name": "jfrog-kiro-power",
       "dest_prefix": "",
       "version_bumps": [

--- a/.github/workflows/sync-plugins.yml
+++ b/.github/workflows/sync-plugins.yml
@@ -5,7 +5,7 @@ name: Sync Plugins
 # at the tag into the plugin repo.
 #
 # Auth: jfrog-agentic-release-bot GitHub App → short-lived installation token.
-#   vars.PUBLIC_REPO_APP_ID + secrets.PUBLIC_REPO_APP_PRIVATE_KEY
+#   vars.PUBLIC_REPO_CLIENT_ID + secrets.PUBLIC_REPO_APP_PRIVATE_KEY
 #   App needs Contents:write + Pull requests:write on every jfrog/<plugin>
 #   repo in plugins.json. Mint with explicit permission-* inputs.
 #   github-api-url is pinned to api.github.com for consistency with the
@@ -32,7 +32,6 @@ on:
           - vscode-plugin
           - codex-plugin
           - opencode-jfrog-plugin
-          - jfrog-devin-extension
           - jfrog-kiro-power
           - devin-plugin
           - jetbrains-plugin
@@ -99,7 +98,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PUBLIC_REPO_APP_ID }}
+          client-id: ${{ vars.PUBLIC_REPO_CLIENT_ID }}
           private-key: ${{ secrets.PUBLIC_REPO_APP_PRIVATE_KEY }}
           owner: jfrog
           repositories: ${{ matrix.name }}

--- a/tests/test_jfrog_sync_plugins.py
+++ b/tests/test_jfrog_sync_plugins.py
@@ -49,10 +49,6 @@ class TestPluginsJsonPinUpdates(unittest.TestCase):
             [{"file": "sync-skills-vendor.json", "path": "pin"}],
         )
         self.assertEqual(
-            by_name["jfrog-devin-extension"]["pin_updates"],
-            [{"file": ".github/scripts/sync-skills-vendor.json", "path": "pin"}],
-        )
-        self.assertEqual(
             by_name["jfrog-kiro-power"]["pin_updates"],
             [{"file": "scripts/sync-skills-vendor.json", "path": "pin"}],
         )


### PR DESCRIPTION
## Summary
- Remove archived `jfrog-devin-extension` from `.github/plugins.json` and the Sync Plugins dropdown. GHES `#138` already dropped it on github.jfrog.info; distribute does not copy `.github/`, so public sync kept failing that one matrix leg (403 on archived repo). Live Devin remains `devin-plugin`.
- Mint `create-github-app-token@v3` with `client-id` (`vars.PUBLIC_REPO_CLIENT_ID`) instead of deprecated `app-id`.

## Test plan
- [x] `python3 tests/test_jfrog_sync_plugins.py`
- [ ] Merge, then next skills release Sync Plugins should be green on all 8 plugins (no Devin-extension job)
